### PR TITLE
Fix battle rewards and location views

### DIFF
--- a/instalacja.md
+++ b/instalacja.md
@@ -1,16 +1,21 @@
 # Instalacja i uruchomienie
 
-1. Zainstaluj zależności:
+1. Zainstaluj zależności z katalogu głównego repozytorium:
 ```bash
 pip install -r requirements.txt
 ```
 
-2. Uruchom migracje:
+2. Przejdź do katalogu aplikacji Django:
+```bash
+cd klon
+```
+
+3. Uruchom migracje:
 ```bash
 python manage.py migrate
 ```
 
-3. Odpal serwer developerski:
+4. Odpal serwer developerski:
 ```bash
 python manage.py runserver
 ```

--- a/klon/lokacje/tests.py
+++ b/klon/lokacje/tests.py
@@ -1,3 +1,82 @@
-from django.test import TestCase
+from unittest.mock import patch
 
-# Create your tests here.
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+from .models import Enemy
+
+
+class LocationViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="fighter", password="pass12345")
+        self.client.login(username="fighter", password="pass12345")
+
+    def test_map_view_uses_fallback_names_when_locations_are_missing(self):
+        response = self.client.get(reverse("mapa"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Zdziczale Lochy")
+
+
+class FightViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="fighter", password="pass12345")
+        self.profile = self.user.userprofile
+        self.profile.attack = 20
+        self.profile.defence = 0
+        self.profile.hp = 50
+        self.profile.stamina = 5
+        self.profile.experience = 0
+        self.profile.gold = 0
+        self.profile.save()
+        self.client.login(username="fighter", password="pass12345")
+
+    @patch("lokacje.views.random.random", return_value=1.0)
+    def test_winning_fight_awards_experience_through_leveling_logic(self, _random):
+        self.profile.experience = 95
+        self.profile.save()
+        enemy = Enemy.objects.create(
+            name="Training Dummy",
+            lvl=10,
+            base_hp=1,
+            base_attack=0,
+            base_defence=0,
+            gold_drop=7,
+        )
+
+        response = self.client.post(reverse("fight", args=[enemy.id]), {"strategy": "balanced"})
+
+        self.assertEqual(response.status_code, 200)
+        self.profile.refresh_from_db()
+        self.assertEqual(self.profile.level, 2)
+        self.assertEqual(self.profile.experience, 95)
+        self.assertEqual(self.profile.gold, 7)
+        self.assertEqual(self.profile.hp, self.profile.max_hp)
+        self.assertEqual(self.profile.stamina, self.profile.max_stamina - 1)
+        self.assertContains(response, "100 expa")
+
+    @patch("lokacje.views.random.random", return_value=1.0)
+    def test_losing_fight_with_zero_hp_applies_death_penalty(self, _random):
+        self.profile.attack = 0
+        self.profile.hp = 5
+        self.profile.stamina = 3
+        self.profile.experience = 100
+        self.profile.save()
+        enemy = Enemy.objects.create(
+            name="Arena Brute",
+            lvl=1,
+            base_hp=999,
+            base_attack=50,
+            base_defence=999,
+            gold_drop=0,
+        )
+
+        response = self.client.post(reverse("fight", args=[enemy.id]), {"strategy": "balanced"})
+
+        self.assertEqual(response.status_code, 200)
+        self.profile.refresh_from_db()
+        self.assertEqual(self.profile.hp, 1)
+        self.assertEqual(self.profile.stamina, 2)
+        self.assertEqual(self.profile.experience, 95)
+        self.assertContains(response, "Utracono 5 expa")

--- a/klon/lokacje/views.py
+++ b/klon/lokacje/views.py
@@ -1,38 +1,47 @@
 from django.shortcuts import render, get_object_or_404
 from django.contrib.auth.decorators import login_required
-from user_profile.models import UserProfile
 from .models import Enemy, Location
 import random
 from inventory.models import InventoryItem
-from django.template.loader import  render_to_string
+from django.template.loader import render_to_string
 from django.http import HttpResponse
 from user_profile.models import UserProfile
 
+
+LOCATION_SLOTS = [
+    (1, "location1", "Zdziczale Lochy"),
+    (2, "location2", "Cyrk Gladiatorow"),
+    (3, "location3", "Pustynne Wzgorza"),
+    (4, "location4", "Rowniny"),
+]
+
 # Widoki lokacji
 def mapa_view(request):
-    locations = [Location.objects.get(id=i) for i in range(1, 5)]
-    context = {f'location{i+1}': loc for i, loc in enumerate(locations)}
+    locations = Location.objects.in_bulk([slot[0] for slot in LOCATION_SLOTS])
+    context = {
+        context_name: locations.get(location_id) or {"name": fallback_name}
+        for location_id, context_name, fallback_name in LOCATION_SLOTS
+    }
     return render(request, 'lokacje/mapa.html', context)
 
-def beast_dung_view(request):
-    location = Location.objects.get(id=1)
+
+def _location_view(request, location_id, template_name):
+    location = get_object_or_404(Location, id=location_id)
     enemies = location.enemies.all()
-    return render(request, 'lokacje/beast_dung.html', {'location': location, 'enemies': enemies})
+    return render(request, template_name, {'location': location, 'enemies': enemies})
+
+
+def beast_dung_view(request):
+    return _location_view(request, 1, 'lokacje/beast_dung.html')
 
 def circus_view(request):
-    location = Location.objects.get(id=2)
-    enemies = location.enemies.all()
-    return render(request, 'lokacje/circus.html', {'location': location, 'enemies': enemies})
+    return _location_view(request, 2, 'lokacje/circus.html')
 
 def dessert_hills_view(request):
-    location = Location.objects.get(id=3)
-    enemies = location.enemies.all()
-    return render(request, 'lokacje/dessert_hills.html', {'location': location, 'enemies': enemies})
+    return _location_view(request, 3, 'lokacje/dessert_hills.html')
 
 def plains_view(request):
-    location = Location.objects.get(id=4)
-    enemies = location.enemies.all()
-    return render(request, 'lokacje/plains.html', {'location': location, 'enemies': enemies})
+    return _location_view(request, 4, 'lokacje/plains.html')
 
 # Silnik walki
 class BattleEngine:
@@ -72,7 +81,7 @@ class BattleEngine:
 
             if enemy_hp <= 0:
                 self.result = 'win'
-                return user_hp, self.result, self.log
+                return user_hp, enemy_hp, self.result, self.log
 
             # Wróg kontratakuje
             enemy_dmg = max(0, self.enemy.base_attack - self.user.defence * def_mod)
@@ -90,7 +99,7 @@ class BattleEngine:
 
             if user_hp <= 0:
                 self.result = 'lose'
-                return user_hp, self.result, self.log
+                return user_hp, enemy_hp, self.result, self.log
 
         self.log.append("🔚 Limit 20 tur osiągnięty.")
         if user_total_dmg >= enemy_total_dmg:
@@ -99,7 +108,7 @@ class BattleEngine:
         else:
             self.log.append("📊 Przegrałeś – przeciwnik zadał więcej obrażeń.")
             self.result = 'lose'
-        return user_hp, self.result, self.log
+        return user_hp, enemy_hp, self.result, self.log
 
 # Widok walki
 @login_required
@@ -120,21 +129,20 @@ def fight_view(request, enemy_id):
     if request.method == 'POST':
         strategy = request.POST.get('strategy', 'balanced')
         engine = BattleEngine(user_profile, enemy, strategy)
-        remaining_hp, result, log = engine.simulate()
-
-        # HP przeciwnika po walce:
-        total_dmg = sum(
-            int(entry.split(" ")[1]) for entry in log
-            if entry.startswith("Zadałeś")
-        )
-        enemy_hp = max(0, enemy.base_hp - total_dmg)
+        remaining_hp, enemy_hp, result, log = engine.simulate()
+        enemy_hp = max(0, enemy_hp)
         enemy_hp_percentage = int((enemy_hp / enemy.base_hp) * 100) if enemy.base_hp else 0
 
 
+        leveled_up = False
+
         if result == 'win':
+            exp_reward = enemy.lvl * 10
+            level_before_reward = user_profile.level
             user_profile.gold += enemy.gold_drop
-            user_profile.experience += enemy.lvl * 6
-            log.append(f"🏆 Wygrałeś! Zdobyto {enemy.gold_drop} złota i {enemy.lvl * 10} expa.")
+            user_profile.dodaj_exp(exp_reward)
+            leveled_up = user_profile.level > level_before_reward
+            log.append(f"🏆 Wygrałeś! Zdobyto {enemy.gold_drop} złota i {exp_reward} expa.")
 
             loot_items = list(enemy.loot_table.all())
             if loot_items and random.random() < float(enemy.drop_chance):
@@ -146,7 +154,7 @@ def fight_view(request, enemy_id):
                 log.append(f"🎁 Znalazłeś przedmiot: {dropped_item.name}!")
             else:
                 log.append("🔎 Tym razem nie znalazłeś żadnego przedmiotu.")
-        elif user_profile.hp <= 0:
+        elif result == 'lose' and remaining_hp <= 0:
             user_profile.hp = 1
             penalty = int(user_profile.experience * 0.05)
             user_profile.experience = max(0, user_profile.experience - penalty)
@@ -154,7 +162,7 @@ def fight_view(request, enemy_id):
         else:
             log.append("⚠️ Przegrałeś walkę, ale przetrwałeś – bez strat.")
 
-        user_profile.hp = max(1, remaining_hp)
+        user_profile.hp = max(1, remaining_hp, user_profile.hp if leveled_up else 1)
         user_profile.stamina = max(0, user_profile.stamina - 1)
         user_profile.save()
 


### PR DESCRIPTION
## Summary
- make the map view tolerate missing seed locations by showing fallback names
- route location pages through a shared 404-safe helper
- fix fight rewards so experience uses the leveling method and matches the displayed reward
- preserve level-up HP/stamina effects after battle resolution
- add regression tests for map rendering and fight win/loss outcomes
- update installation docs to enter the Django app directory before running manage.py

## Tests
- `..\.venv\Scripts\python.exe manage.py test` from `klon/` -> 12 tests OK