### PR TITLE
Polish project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,86 @@
-# Klon gry Gladiatus na technologii Django, htmx, alpine.js i tailwind.css
+# Klon Gladiatusa
 
-## Plan działania
+Przeglądarkowa gra RPG inspirowana Gladiatusem, zbudowana w Django. Projekt skupia się na klasycznym loopie rozgrywki: rozwój postaci, ekwipunek, walka z przeciwnikami, zdobywanie łupu oraz handel z NPC.
 
-### Profil:
-- Statystyki:
-  - Siła ✅
-  - Zwinność ✅
-  - Budowa fizyczna ✅
-  - Intelekt ✅
-- Doświadczenie:
-  - Poziomy ✅
-  - Punkty statystyk ✅
-  - Skalowanie punktów doświadczenia ✅
-- Ekwipunek:
-  - Wyposażenie✅
-  - Plecak✅
-  - Portfel/złoto✅
+## Spis treści
 
-### Walka:
-- 2/3 lokalizacje z 3/4 przeciwnikami✅
-- Loot z pokonanych przeciwników:
-  - Przedmioty, doświadczenie, złoto✅
-- System kontroli ilości walk (anti-cheese)✅
+- [Najważniejsze funkcje](#najważniejsze-funkcje)
+- [Stack technologiczny](#stack-technologiczny)
+- [Szybki start](#szybki-start)
+- [Dokumentacja](#dokumentacja)
+- [Status projektu](#status-projektu)
+- [Roadmapa](#roadmapa)
+- [Autorzy](#autorzy)
 
-### Autoryzacja:
-- Logowanie ✅
-- Rejestracja ✅
+## Najważniejsze funkcje
 
-### Handlarz:
-- Kupowanie✅
-- Sprzedawanie✅
+| Obszar | Status | Opis |
+| --- | --- | --- |
+| Profil gracza | Gotowe | Statystyki bazowe i pochodne, poziomy, doświadczenie, punkty statystyk, HP i stamina. |
+| Walka | Gotowe | Lokacje z przeciwnikami, strategie walki, log walki, nagrody, koszt staminy i loot. |
+| Ekwipunek | Gotowe | Plecak, zakładanie i zdejmowanie przedmiotów, bonusy ze statystyk wyposażenia. |
+| Przedmioty | Gotowe | Typy ekwipunku, mikstury, poziom przedmiotu, wartość, obrażenia i bonusy. |
+| Handlarze | Gotowe | Kowal i alchemik, oferty czasowe, kupowanie oraz sprzedawanie. |
+| Autoryzacja | Gotowe | Rejestracja, logowanie i wylogowanie użytkownika. |
+| Interakcje HTMX | Gotowe | Fragmenty widoków dla walki, banneru gracza, plecaka i ofert handlarzy. |
 
-TBC...
+## Stack technologiczny
 
-### Baza danych:
-- SQLite - patrząc na rozmiar projektu i dodatkowo na plus wbudowana integracja z Django ✅
-- PostgreSQL - dla "etapu" hostingu, wtedy można wymagać optymalizacji i szybkości i największy plus pełna funkcjonalność na darmowej licencji.
+- Python 3.x
+- Django 5.1
+- SQLite jako baza developerska
+- Django templates
+- HTMX
+- Alpine.js
+- Tailwind CSS przez CDN
+- Pillow dla obrazów i portretów przeciwników
 
-## Sposób interakcji
+## Szybki start
 
-Projekt będzie miał interfejs graficzny (GUI) oparty na technologiach Django, htmx, alpine.js i tailwind.css. Użytkownicy będą mogli wchodzić w interakcje z aplikacją za pomocą przeglądarki internetowej.
+Pełna instrukcja znajduje się w pliku [instalacja.md](instalacja.md). Minimalny scenariusz lokalny:
 
-## Zaimplementowane funkcjonalności
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+cd klon
+python manage.py migrate
+python manage.py runserver
+```
 
-### Profil:
-- Statystyki:
-  - Siła ✅
-  - Zwinność ✅
-  - Budowa fizyczna ✅
-  - Intelekt ✅
-- Doświadczenie:
-  - Poziomy ✅
-  - Punkty statystyk ✅
-  - Skalowanie punktów doświadczenia ✅
+Po uruchomieniu aplikacja będzie dostępna pod adresem:
 
-### Autoryzacja:
-- Logowanie ✅
-- Rejestracja ✅
+```text
+http://127.0.0.1:8000/
+```
 
-### Baza danych:
-- SQLite ✅
+## Dokumentacja
 
-## Zawartość dokumentacji
-
-- [Instalacja](instalacja.md)
+- [Instalacja i uruchomienie](instalacja.md)
 - [Struktura projektu](struktura.md)
-- [API – moduły](api.md)
+- [Dokumentacja modułów](api.md)
 
-## Autorzy:
+## Status projektu
+
+Projekt jest grywalnym prototypem. Najważniejsze systemy są już połączone, ale kod nadal ma miejsca typowe dla etapu rozwoju:
+
+- konfiguracja produkcyjna nie jest jeszcze wydzielona ze `settings.py`,
+- baza SQLite i pliki mediów są traktowane jako lokalne środowisko developerskie,
+- część tras i widoków wymaga dalszego porządkowania,
+- balans walki, dropów i ekonomii można rozwijać iteracyjnie.
+
+## Roadmapa
+
+Najbardziej naturalne kolejne kroki:
+
+1. Wydzielenie ustawień środowiskowych: `SECRET_KEY`, `DEBUG`, `ALLOWED_HOSTS`, baza danych.
+2. Uporządkowanie routingu profilu i endpointów HTMX.
+3. Dodanie seedów lub komend management dla lokacji, przeciwników i przedmiotów startowych.
+4. Rozbudowa testów walki, ekwipunku, handlu i rejestracji.
+5. Dodanie widoku administracyjnego lub panelu do zarządzania balansem gry.
+6. Przygotowanie konfiguracji pod hosting z PostgreSQL.
+
+## Autorzy
+
 - Denis Kuczka
 - Mateusz Rduch
-

--- a/api.md
+++ b/api.md
@@ -1,65 +1,296 @@
-# API – moduły i komponenty
+# Dokumentacja modułów
 
-## inventory
+Ten plik opisuje wewnętrzne moduły projektu. Nie jest to publiczne REST API, tylko mapa modeli, widoków, tras i zależności między aplikacjami Django.
 
-- `admin.py`
-- `apps.py`
-- `context_processors.py`
-- `models.py`
-- `tests.py`
-- `urls.py`
-- `views.py`
+## Przegląd aplikacji
 
-## items
+| Aplikacja | Główna rola |
+| --- | --- |
+| `members` | Konta użytkowników: rejestracja, logowanie, wylogowanie. |
+| `user_profile` | Dane gracza: statystyki, poziom, doświadczenie, HP, stamina, złoto. |
+| `items` | Definicje przedmiotów, slotów, mikstur i bonusów. |
+| `inventory` | Instancje przedmiotów przypisane do użytkownika oraz obsługa wyposażenia. |
+| `lokacje` | Lokacje, przeciwnicy, mapa i walka. |
+| `merchant` | Handlarze, rotujące oferty, kupowanie i sprzedawanie. |
+| `klon_gl` | Konfiguracja całego projektu Django. |
 
-- `admin.py`
-- `apps.py`
-- `models.py`
-- `tests.py`
-- `views.py`
+## `klon_gl`
 
-## klon_gl
+Główna konfiguracja Django.
 
-- `asgi.py`
-- `settings.py`
-- `urls.py`
-- `wsgi.py`
+### Najważniejsze pliki
 
-## lokacje
+| Plik | Rola |
+| --- | --- |
+| `settings.py` | Zainstalowane aplikacje, middleware, baza SQLite, statyczne pliki, media, język i strefa czasu. |
+| `urls.py` | Główna mapa URL-i projektu. |
+| `asgi.py` | Wejście ASGI. |
+| `wsgi.py` | Wejście WSGI. |
 
-- `admin.py`
-- `apps.py`
-- `models.py`
-- `tests.py`
-- `urls.py`
-- `views.py`
+### Główne trasy
 
-## members
+| URL | Cel |
+| --- | --- |
+| `/` | Przekierowanie do profilu gracza. |
+| `/admin/` | Panel administratora Django. |
+| `/members/` | Trasy logowania i rejestracji. |
+| `/user_profile/` | Profil gracza i rozdawanie statystyk. |
+| `/lokacje/` | Mapa, lokacje i walka. |
+| `/merchant/` | Handlarze. |
+| `/inventory/` | Plecak i wyposażenie. |
 
-- `admin.py`
-- `apps.py`
-- `models.py`
-- `tests.py`
-- `urls.py`
-- `views.py`
+## `members`
 
-## merchant
+Obsługuje podstawową autoryzację użytkownika.
 
-- `admin.py`
-- `apps.py`
-- `models.py`
-- `tests.py`
-- `urls.py`
-- `utils.py`
-- `views.py`
+### Widoki
 
-## user_profile
+| Widok | Rola |
+| --- | --- |
+| `login_user` | Loguje użytkownika i przekierowuje do profilu. |
+| `logout_user` | Wylogowuje użytkownika i wraca do formularza logowania. |
+| `register_user` | Tworzy konto przez `UserCreationForm`, loguje użytkownika i przechodzi do profilu. |
 
-- `admin.py`
-- `apps.py`
-- `forms.py`
-- `models.py`
-- `signals.py`
-- `tests.py`
-- `urls.py`
-- `views.py`
+### Trasy
+
+| URL | Nazwa |
+| --- | --- |
+| `/members/login_user` | `login_user` |
+| `/members/logout_user` | `logout_user` |
+| `/members/register_user` | `register_user` |
+
+## `user_profile`
+
+Centralny moduł postaci gracza.
+
+### Model `UserProfile`
+
+Najważniejsze pola:
+
+| Grupa | Pola |
+| --- | --- |
+| Użytkownik | `user` |
+| Statystyki | `strength`, `dexterity`, `constitution`, `intelligence` |
+| Statystyki bazowe | `base_strength`, `base_dexterity`, `base_constitution`, `base_intelligence` |
+| Rozwój | `level`, `experience`, `stat_points` |
+| Zasoby | `gold`, `hp`, `max_hp`, `stamina`, `max_stamina` |
+| Walka | `attack`, `base_attack`, `defence`, `base_defence` |
+| Regeneracja | `last_regen`, `last_regen_stm` |
+
+### Metody modelu
+
+| Metoda | Rola |
+| --- | --- |
+| `lvlup_exp()` | Wylicza wymagane doświadczenie do kolejnego poziomu. |
+| `dodaj_exp(exp)` | Dodaje doświadczenie i obsługuje awans. |
+| `lvlup()` | Podnosi poziom, dodaje punkty statystyk i odnawia HP oraz staminę. |
+| `hp_regen()` | Regeneruje HP na podstawie czasu, inteligencji i budowy fizycznej. |
+| `stamina_regen()` | Regeneruje staminę na podstawie czasu i inteligencji. |
+| `equipped_items()` | Pobiera założone przedmioty użytkownika. |
+| `update_stats()` | Przelicza statystyki po zmianie ekwipunku lub statystyk bazowych. |
+
+### Widoki
+
+| Widok | Rola |
+| --- | --- |
+| `WidokProfilu` | Główny widok profilu gracza. |
+| `WidokRozdaniaStaystyk` | Dodaje punkt do wybranej statystyki. |
+| `profil_gracza` | Funkcyjna wersja widoku profilu. Obecnie trasa jest powielona z `WidokProfilu`. |
+
+### Sygnały
+
+`create_user_profile` tworzy `UserProfile` automatycznie po utworzeniu użytkownika Django.
+
+## `items`
+
+Definiuje przedmioty dostępne w grze.
+
+### Model `Item`
+
+| Pole | Rola |
+| --- | --- |
+| `name`, `description` | Nazwa i opis przedmiotu. |
+| `rarity` | Rzadkość: common, uncommon, rare, epic, legendary. |
+| `slot` | Slot ekwipunku, na przykład weapon, shield, head, chest. |
+| `item_type` | Typ: ekwipunek, mikstura HP, mikstura staminy. |
+| `item_level` | Poziom przedmiotu. |
+| `dmg`, `dmg_min`, `dmg_max` | Obrażenia. |
+| `item_strength`, `item_dexterity`, `item_constitution`, `item_intelligence` | Bonusy statystyk. |
+| `value` | Wartość przedmiotu u handlarzy. |
+| `effect_value` | Wartość efektu mikstury. |
+
+### Metody
+
+| Metoda | Rola |
+| --- | --- |
+| `dmg_calc()` | Wylicza minimalne i maksymalne obrażenia na podstawie `dmg`. |
+
+## `inventory`
+
+Łączy użytkowników z konkretnymi egzemplarzami przedmiotów.
+
+### Model `InventoryItem`
+
+| Pole | Rola |
+| --- | --- |
+| `user` | Właściciel przedmiotu. |
+| `item` | Definicja przedmiotu z aplikacji `items`. |
+| `equipped` | Informacja, czy przedmiot jest założony. |
+
+### Widoki
+
+| Widok | Rola |
+| --- | --- |
+| `backpack_view` | Wyświetla plecak użytkownika. |
+| `equip_item` | Zakłada przedmiot i zdejmuje poprzedni przedmiot z tego samego slotu. |
+| `unequip_item` | Zdejmuje przedmiot. |
+| `give_item` | Dodaje przedmiot użytkownikowi, przydatne developersko. |
+| `use_potion` | Zużywa miksturę HP lub staminy. |
+| `refresh_banner` | Odświeża pasek stanu gracza przez HTMX. |
+
+### Trasy
+
+| URL | Nazwa |
+| --- | --- |
+| `/inventory/plecak/` | `backpack` |
+| `/inventory/equip/<item_id>/` | `equip_item` |
+| `/inventory/unequip/<item_id>/` | `unequip_item` |
+| `/inventory/give/<item_id>/` | `give_item` |
+| `/inventory/use/<item_id>/` | `use_potion` |
+| `/inventory/ajax/refresh-banner/` | `refresh_banner` |
+
+## `lokacje`
+
+Odpowiada za mapę świata, lokacje, przeciwników i walkę.
+
+### Model `Enemy`
+
+| Pole | Rola |
+| --- | --- |
+| `name`, `description` | Nazwa i opis przeciwnika. |
+| `lvl`, `type` | Poziom i typ przeciwnika: normalny, elita, boss. |
+| `base_strenght`, `base_intelect`, `base_dexterity`, `base_constitution` | Bazowe statystyki przeciwnika. |
+| `base_hp`, `base_attack`, `base_defence` | Statystyki bojowe. |
+| `gold_drop`, `drop_chance`, `loot_table` | Nagrody za pokonanie przeciwnika. |
+| `portrait` | Portret przeciwnika. |
+
+### Model `Location`
+
+| Pole | Rola |
+| --- | --- |
+| `name` | Nazwa lokacji. |
+| `enemies` | Przeciwnicy dostępni w lokacji. |
+
+### Silnik walki
+
+`BattleEngine` symuluje walkę turową:
+
+- wybiera modyfikatory strategii: agresywnej, defensywnej albo zbalansowanej,
+- liczy obrażenia gracza i przeciwnika,
+- obsługuje trafienia krytyczne, blok i unik,
+- kończy walkę po śmierci jednej ze stron albo po limicie 20 tur,
+- zwraca końcowe HP gracza, HP przeciwnika, wynik i log walki.
+
+### Widoki
+
+| Widok | Rola |
+| --- | --- |
+| `mapa_view` | Wyświetla mapę i nazwy lokacji. |
+| `beast_dung_view` | Lokacja Zdziczałe Lochy. |
+| `circus_view` | Lokacja Cyrk Gladiatorów. |
+| `dessert_hills_view` | Lokacja Pustynne Wzgórza. |
+| `plains_view` | Lokacja Równiny. |
+| `fight_view` | Obsługuje formularz walki, koszt staminy, nagrody, loot i wynik. |
+| `refresh_banner` | Odświeża pasek stanu gracza po walce. |
+
+### Trasy
+
+| URL | Nazwa |
+| --- | --- |
+| `/lokacje/` | `mapa` |
+| `/lokacje/beast_dungeon/` | `beast_dung` |
+| `/lokacje/circus/` | `circus` |
+| `/lokacje/dessert_hills/` | `dessert_hills` |
+| `/lokacje/plains/` | `plains` |
+| `/lokacje/fight/<enemy_id>/` | `fight` |
+| `/lokacje/ajax/refresh-banner/` | `refresh_banner` |
+
+## `merchant`
+
+Odpowiada za handel z NPC.
+
+### Model `MerchantOffer`
+
+| Pole | Rola |
+| --- | --- |
+| `item` | Przedmiot w ofercie. |
+| `price` | Cena zakupu. |
+| `available_until` | Czas wygaśnięcia oferty. |
+| `type` | Typ handlarza: kowal albo alchemik. |
+| `stock` | Liczba dostępnych sztuk. |
+
+### Generowanie ofert
+
+| Funkcja | Rola |
+| --- | --- |
+| `generate_blacksmith_offer()` | Tworzy czasową ofertę ekwipunku dla kowala. |
+| `generate_alchemist_offer()` | Tworzy czasową ofertę mikstur dla alchemika. |
+
+### Widoki
+
+| Widok | Rola |
+| --- | --- |
+| `blacksmith_page_view` | Strona kowala z ofertą i plecakiem gracza. |
+| `blacksmith_offer_fragment` | Fragment HTMX z ofertą kowala. |
+| `buy_offer_view` | Kupowanie przedmiotu od kowala. |
+| `sell_to_merchant` | Sprzedaż przedmiotu kowalowi. |
+| `alchemist_page_view` | Strona alchemika z ofertą i plecakiem gracza. |
+| `buy_offer_alchemist` | Kupowanie mikstury od alchemika. |
+| `sell_to_alchemist` | Sprzedaż przedmiotu alchemikowi. |
+| `backpack_fragment`, `backpack_fragment_alchemist` | Fragmenty HTMX plecaka. |
+| `merchant_view` | Ogólny widok handlarza. |
+
+### Trasy
+
+| URL | Nazwa |
+| --- | --- |
+| `/merchant/blacksmith/` | `blacksmith_page` |
+| `/merchant/blacksmith/offer/` | `blacksmith_offer` |
+| `/merchant/blacksmith/offers/` | `blacksmith_offer_fragment` |
+| `/merchant/blacksmith/buy/<offer_id>/` | `buy_offer` |
+| `/merchant/blacksmith/sell/<item_id>/` | `sell_to_merchant` |
+| `/merchant/blacksmith/backpack-fragment/` | `backpack_fragment` |
+| `/merchant/merchant/` | `merchant_view` |
+| `/merchant/alchemist/` | `alchemist` |
+| `/merchant/alchemist/buy/<offer_id>/` | `buy_offer_alchemist` |
+| `/merchant/alchemist/sell/<item_id>/` | `sell_to_alchemist` |
+| `/merchant/alchemist/backpack-fragment/` | `backpack_fragment_alchemist` |
+
+## Zależności między modułami
+
+```text
+User
+└── UserProfile
+    ├── InventoryItem
+    │   └── Item
+    ├── BattleEngine
+    │   └── Enemy
+    │       └── loot_table -> Item
+    └── MerchantOffer
+        └── Item
+```
+
+## Testy
+
+Testy są uruchamiane przez Django:
+
+```bash
+cd klon
+python manage.py test
+```
+
+Najważniejsze aktualne obszary testów:
+
+- levelowanie i regeneracja profilu gracza,
+- renderowanie mapy lokacji,
+- podstawowe scenariusze wygranej i przegranej walki.

--- a/instalacja.md
+++ b/instalacja.md
@@ -1,21 +1,128 @@
 # Instalacja i uruchomienie
 
-1. Zainstaluj zależności z katalogu głównego repozytorium:
+Ten projekt jest aplikacją Django umieszczoną w katalogu `klon/`. Zależności są trzymane w `requirements.txt` w katalogu głównym repozytorium.
+
+## Wymagania
+
+- Python 3.x
+- Git
+- Dostęp do terminala
+
+Na Windowsie, jeśli komenda `python` otwiera Microsoft Store, użyj launchera `py`, na przykład `py -3.13`.
+
+## 1. Pobranie projektu
+
+```bash
+git clone https://github.com/Exhil95/klon_gladiatusa.git
+cd klon_gladiatusa
+```
+
+## 2. Środowisko wirtualne
+
+Windows PowerShell:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+```
+
+Windows przez launcher `py`:
+
+```powershell
+py -3.13 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+```
+
+Linux/macOS:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+## 3. Instalacja zależności
+
 ```bash
 pip install -r requirements.txt
 ```
 
-2. Przejdź do katalogu aplikacji Django:
+## 4. Migracje bazy danych
+
+Przejdź do katalogu aplikacji Django:
+
 ```bash
 cd klon
 ```
 
-3. Uruchom migracje:
+Uruchom migracje:
+
 ```bash
 python manage.py migrate
 ```
 
-4. Odpal serwer developerski:
+Opcjonalnie utwórz konto administratora:
+
+```bash
+python manage.py createsuperuser
+```
+
+## 5. Uruchomienie serwera
+
 ```bash
 python manage.py runserver
 ```
+
+Aplikacja będzie dostępna pod adresem:
+
+```text
+http://127.0.0.1:8000/
+```
+
+Panel administratora:
+
+```text
+http://127.0.0.1:8000/admin/
+```
+
+## 6. Testy
+
+Testy uruchamiaj z katalogu `klon/`:
+
+```bash
+python manage.py test
+```
+
+Jeśli korzystasz z Windowsowego launchera:
+
+```powershell
+py -3.13 manage.py test
+```
+
+## Przydatne komendy
+
+```bash
+python manage.py makemigrations
+python manage.py migrate
+python manage.py createsuperuser
+python manage.py test
+python manage.py runserver
+```
+
+## Rozwiązywanie problemów
+
+| Problem | Co sprawdzić |
+| --- | --- |
+| `ModuleNotFoundError` | Czy aktywowane jest `.venv` i czy wykonano `pip install -r requirements.txt`. |
+| `manage.py` nie istnieje | Czy terminal jest w katalogu `klon/`, a nie w katalogu głównym repozytorium. |
+| Brak lokacji lub przeciwników | Czy baza zawiera dane startowe dodane przez panel admina, fixture albo ręcznie. |
+| Błędy obrazów przeciwników | Czy pliki istnieją w `klon/media/portraits/` i czy rekordy w bazie wskazują poprawne ścieżki. |
+
+## Uwagi produkcyjne
+
+Obecna konfiguracja jest developerska. Przed hostingiem należy co najmniej:
+
+- przenieść `SECRET_KEY` do zmiennych środowiskowych,
+- ustawić `DEBUG = False`,
+- uzupełnić `ALLOWED_HOSTS`,
+- skonfigurować statyczne pliki i media,
+- rozważyć PostgreSQL zamiast SQLite.

--- a/struktura.md
+++ b/struktura.md
@@ -1,9 +1,107 @@
 # Struktura projektu
 
-- `inventory/` – logika ekwipunku i przedmiotów
-- `items/` – definicje przedmiotów gry
-- `klon_gl/` – główna konfiguracja Django (settings, urls, WSGI)
-- `lokacje/` – logika lokacji w grze
-- `members/` – system członkowski, konta
-- `merchant/` – system handlarzy/NPC
-- `user_profile/` – profil gracza, formularze, sygnały
+Repozytorium składa się z katalogu głównego z dokumentacją i zależnościami oraz katalogu `klon/`, który jest właściwym projektem Django.
+
+```text
+klon_gladiatusa/
+├── README.md
+├── instalacja.md
+├── struktura.md
+├── api.md
+├── requirements.txt
+└── klon/
+    ├── manage.py
+    ├── db.sqlite3
+    ├── klon_gl/
+    ├── members/
+    ├── user_profile/
+    ├── lokacje/
+    ├── inventory/
+    ├── items/
+    ├── merchant/
+    ├── templates/
+    ├── static/
+    └── media/
+```
+
+## Katalog główny
+
+| Ścieżka | Rola |
+| --- | --- |
+| `README.md` | Główna strona projektu: opis, funkcje, szybki start i roadmapa. |
+| `instalacja.md` | Instrukcja instalacji, uruchomienia i testowania. |
+| `struktura.md` | Opis organizacji katalogów i odpowiedzialności modułów. |
+| `api.md` | Dokumentacja wewnętrznych modułów, modeli, widoków i tras. |
+| `requirements.txt` | Lista zależności Pythona. |
+| `.vscode/launch.json` | Konfiguracja uruchamiania Django w Visual Studio Code. |
+
+## Projekt Django: `klon/`
+
+| Ścieżka | Rola |
+| --- | --- |
+| `manage.py` | Główne narzędzie administracyjne Django. |
+| `db.sqlite3` | Lokalna baza developerska SQLite. |
+| `klon_gl/` | Konfiguracja projektu Django. |
+| `templates/` | Wspólne szablony, takie jak `base.html`, `navbar.html`, `sidebar.html`, `banner_up.html`. |
+| `static/` | Pliki statyczne: CSS, HTMX, Alpine.js, obrazy. |
+| `media/` | Pliki wgrywane lub używane jako media, między innymi portrety przeciwników. |
+
+## Aplikacje Django
+
+| Aplikacja | Odpowiedzialność |
+| --- | --- |
+| `members/` | Logowanie, rejestracja i wylogowanie użytkowników. |
+| `user_profile/` | Profil gracza, statystyki, HP, stamina, exp, levelowanie i sygnał tworzenia profilu. |
+| `lokacje/` | Lokacje, przeciwnicy, mapa oraz silnik walki. |
+| `inventory/` | Plecak, zakładanie przedmiotów, zdejmowanie przedmiotów, mikstury i banner gracza. |
+| `items/` | Definicje przedmiotów, typy, sloty, obrażenia, bonusy i wartość. |
+| `merchant/` | Handlarze, oferty czasowe, kupowanie i sprzedawanie. |
+
+## Konwencje Django w projekcie
+
+Każda aplikacja trzyma standardowe pliki Django:
+
+- `models.py` dla modeli bazy danych,
+- `views.py` dla widoków i logiki HTTP,
+- `urls.py` dla tras aplikacji, jeśli aplikacja wystawia endpointy,
+- `admin.py` dla konfiguracji panelu admina,
+- `tests.py` dla testów,
+- `migrations/` dla migracji bazy danych,
+- `templates/<nazwa_aplikacji>/` dla szablonów aplikacji.
+
+## Szablony i frontend
+
+Projekt używa klasycznych szablonów Django, z warstwą interakcji opartą o HTMX i Alpine.js.
+
+Najważniejsze wspólne szablony:
+
+- `klon/templates/base.html` - główny layout,
+- `klon/templates/sidebar.html` - boczna nawigacja,
+- `klon/templates/navbar.html` - nawigacja górna,
+- `klon/templates/banner_up.html` - pasek stanu gracza,
+- `klon/templates/enemy_list.html` - lista przeciwników w lokacji.
+
+Szablony aplikacyjne są trzymane wewnątrz aplikacji, na przykład:
+
+- `klon/lokacje/templates/lokacje/`,
+- `klon/inventory/templates/inventory/`,
+- `klon/merchant/templates/merchants/`,
+- `klon/members/templates/authenticate/`,
+- `klon/user_profile/templates/profil_gracza/`.
+
+## Pliki statyczne i media
+
+| Ścieżka | Zawartość |
+| --- | --- |
+| `klon/static/css/custom.css` | Dodatkowe style projektu. |
+| `klon/static/js/htmx.min.js` | Lokalna kopia HTMX. |
+| `klon/static/js/alpine.min.js` | Lokalna kopia Alpine.js. |
+| `klon/static/images/` | Obrazy interfejsu, tło, favicon, mapa. |
+| `klon/media/portraits/` | Portrety przeciwników używane przez model `Enemy`. |
+
+## Uwagi porządkowe
+
+- `klon/` jest katalogiem, z którego należy uruchamiać `manage.py`.
+- `db.sqlite3` ułatwia lokalny rozwój, ale dla produkcji warto użyć migracji i osobnej bazy.
+- `items/` nie ma obecnie własnego `urls.py`, ponieważ definicje przedmiotów są używane przez inne aplikacje.
+- `user_profile/urls.py` zawiera powieloną trasę `profil/`; Django używa pierwszego pasującego wzorca.


### PR DESCRIPTION
## Summary
- rewrite README into a complete project landing page with feature overview, stack, quick start, status, and roadmap
- expand installation docs with virtualenv setup, migrations, admin account, tests, troubleshooting, and production notes
- replace the project structure note with a proper directory map and module responsibilities
- turn api.md into internal module documentation for models, views, routes, and dependencies

## Tests
- `..\.venv\Scripts\python.exe manage.py test` from `klon/` -> 12 tests OK